### PR TITLE
Convert to existing Cuda Quantum Python APIs

### DIFF
--- a/qwrapper/circuit.py
+++ b/qwrapper/circuit.py
@@ -577,58 +577,59 @@ class CUDAQuantumCircuit(QWrapper):
         self.gatesToApply = []
         #print("Create CUDAQ Circuit")
         self.numQubits = nqubit 
-        self.qarg = cudaq.qvector(nqubit)
+        self.kernel = cudaq.make_kernel()
+        self.qarg = self.kernel.qalloc(self.numQubits)
 
     def copy(self):
         raise NotImplementedError('cuda quantum copy - not supported.')
 
     def h(self, index):
         #print("h {}".format(index))
-        self.gatesToApply.append(lambda qarg : cudaq.h(qarg[index]))
+        self.gatesToApply.append(lambda qarg : self.kernel.h(qarg[index]))
 
     def x(self, index):
         #print("x {}".format(index))
-        self.gatesToApply.append(lambda qarg : cudaq.x(qarg[index]))
+        self.gatesToApply.append(lambda qarg : self.kernel.x(qarg[index]))
 
     def y(self, index):
         #print("y {}".format(index))
-        self.gatesToApply.append(lambda qarg : cudaq.y(qarg[index]))
+        self.gatesToApply.append(lambda qarg : self.kernel.y(qarg[index]))
 
     def z(self, index):
         #print("z {}".format(index))
-        self.gatesToApply.append(lambda qarg : cudaq.z(qarg[index]))
+        self.gatesToApply.append(lambda qarg : self.kernel.z(qarg[index]))
 
     def s(self, index):
         #print("s {}".format(index))
-        self.gatesToApply.append(lambda qarg : cudaq.s(qarg[index]))
+        self.gatesToApply.append(lambda qarg : self.kernel.s(qarg[index]))
 
     def sdag(self, index):
         #print("sdg {}".format(index))
-        self.gatesToApply.append(lambda qarg : cudaq.s.adj(qarg[index]))
+        self.gatesToApply.append(lambda qarg : self.kernel.sdg(qarg[index]))
 
     def rx(self, theta, index):
         #print("rx({}) {}".format(theta, index))
-        self.gatesToApply.append(lambda qarg : cudaq.rx(theta, qarg[index]))
+        self.gatesToApply.append(lambda qarg : self.kernel.rx(theta, qarg[index]))
 
     def ry(self, theta, index):
         #print("ry({}) {}".format(theta, index))
-        self.gatesToApply.append(lambda qarg : cudaq.ry(theta, qarg[index]))
+        self.gatesToApply.append(lambda qarg : self.kernel.ry(theta, qarg[index]))
 
     def rz(self, theta, index):
         #print("rz({}) {}".format(theta, index))
-        self.gatesToApply.append(lambda qarg : cudaq.rz(theta, qarg[index]))
+        self.gatesToApply.append(lambda qarg : self.kernel.rz(theta, qarg[index]))
 
     def cnot(self, c_index, t_index):
         #print("cx {} {}".format(c_index, t_index))
-        self.gatesToApply.append(lambda qarg : cudaq.x.ctrl(qarg[c_index], qarg[t_index]))
+        self.gatesToApply.append(lambda qarg : self.kernel.cx(qarg[c_index], qarg[t_index]))
 
     def cy(self, c_index, t_index):
         #print("cy {} {}".format(c_index, t_index))
-        self.gatesToApply.append(lambda qarg : cudaq.y.ctrl(qarg[c_index], qarg[t_index]))
+        self.gatesToApply.append(lambda qarg : self.kernel.cy(qarg[c_index], qarg[t_index]))
 
     def cz(self, c_index, t_index):
         #print("cz {} {}".format(c_index, t_index))
-        self.gatesToApply.append(lambda qarg : cudaq.z.ctrl(qarg[c_index], qarg[t_index]))
+        self.gatesToApply.append(lambda qarg : self.kernel.cz(qarg[c_index], qarg[t_index]))
 
     def barrier(self):
         pass

--- a/qwrapper/obs.py
+++ b/qwrapper/obs.py
@@ -162,16 +162,14 @@ class Hamiltonian(Obs):
         if isinstance(qc, CUDAQuantumCircuit):
             if self._cudaq_obs is None:
                 self._cudaq_obs = self._build_cudaq_obs()
-            @cudaq.kernel
-            def eval():
-                q = cudaq.qvector(qc.numQubits)
-                [op(q) for op in qc.gatesToApply]
+            for op in qc.gatesToApply:
+                op(qc.qarg)
             
             if 'parallelObserve' in kwargs and kwargs['parallelObserve']:
                 print("Async exec on qpu {}".format(kwargs['qpu_id']))
-                return cudaq.observe_async(eval, self._cudaq_obs, qpu_id=kwargs['qpu_id'])
+                return cudaq.observe_async(qc.kernel, self._cudaq_obs, qpu_id=kwargs['qpu_id'])
             
-            return cudaq.observe(eval, self._cudaq_obs).expectation_z()
+            return cudaq.observe(qc.kernel, self._cudaq_obs).expectation_z()
 
         if isinstance(qc, QulacsCircuit):
             if self._qulacs_obs is None:

--- a/qwrapper/operator.py
+++ b/qwrapper/operator.py
@@ -18,8 +18,9 @@ class PauliTimeEvolution(Operator):
 
     def add_circuit(self, qc: QWrapper):
         if isinstance(qc, CUDAQuantumCircuit):
-            qc.gatesToApply.append(lambda qarg: cudaq.exp_pauli(
-                qarg, self.pauli.sign * self.t, cudaq.SpinOperator.from_word(self.pauli.p_string)))
+            if self.pauli.p_string != len(self.pauli.p_string) * 'I':
+                qc.gatesToApply.append(lambda qarg: qc.kernel.exp_pauli(
+                    self.pauli.sign * self.t, qarg, self.pauli.p_string))
             return
 
         if not isinstance(qc, QulacsCircuit) or not self.cachable:


### PR DESCRIPTION
Build CUDA Quantum kernel the usual way with the `kernel_builder` + `exp_pauli` so we can use stock CUDA Quantum from `pip install` or `docker`. 